### PR TITLE
Add pipelines/jobs/secrets for the k8s-cluster-api-provider e2e tests

### DIFF
--- a/playbooks/openstack/access.yaml
+++ b/playbooks/openstack/access.yaml
@@ -1,0 +1,16 @@
+---
+- name: OpenStack access configuration file
+  hosts: all
+  tasks:
+    - name: Ensure openstack directory exists
+      file:
+        path: "/etc/openstack"
+        state: directory
+    - name: Create clouds.yaml
+      template:
+        src: "templates/clouds.yaml.j2"
+        dest: "/etc/openstack/clouds.yaml"
+    - name: Create secure.yaml
+      template:
+        src: "templates/secure.yaml.j2"
+        dest: "/etc/openstack/secure.yaml"

--- a/playbooks/openstack/templates/clouds.yaml.j2
+++ b/playbooks/openstack/templates/clouds.yaml.j2
@@ -1,0 +1,7 @@
+clouds:
+  {{ cloud }}:
+    region_name: "RegionOne"
+    interface: "public"
+    identity_api_version: 3
+    auth:
+      auth_url: https://api.gx-scs.sovereignit.cloud:5000

--- a/playbooks/openstack/templates/secure.yaml.j2
+++ b/playbooks/openstack/templates/secure.yaml.j2
@@ -1,0 +1,6 @@
+clouds:
+  {{ cloud }}:
+    auth_type: "v3applicationcredential"
+    auth:
+      application_credential_id: {{ openstack_appcred.id }}
+      application_credential_secret: {{ openstack_appcred.secret }}

--- a/zuul.d/gh_pipelines.yaml
+++ b/zuul.d/gh_pipelines.yaml
@@ -115,3 +115,135 @@
       githubzuulapp:
         - event: push
           ref: ^refs/tags/.*$
+
+- pipeline:
+    name: e2e-test
+    description: |
+      Changes that have been seen by trusted reviewer who labeled PR by e2e-test label
+    success-message: Build succeeded (e2e-test pipeline).
+    failure-message: Build failed (e2e-test pipeline).
+    dequeue-message: Build canceled (e2e-test pipeline).
+    manager: independent
+    trigger:
+      githubzuulapp:
+        - event: pull_request
+          action: labeled
+          label:
+            - e2e-test
+    start:
+      githubzuulapp:
+        check: 'in_progress'
+        comment: false
+    success:
+      githubzuulapp:
+        check: 'success'
+        comment: true
+        label:
+          - successful-e2e-test
+        unlabel:
+          - e2e-test
+          - failed-e2e-test
+          - cancelled-e2e-test
+    failure:
+      githubzuulapp:
+        check: 'failure'
+        comment: true
+        label:
+          - failed-e2e-test
+        unlabel:
+          - e2e-test
+    dequeue:
+      githubzuulapp:
+        check: cancelled
+        comment: true
+        label:
+          - cancelled-e2e-test
+        unlabel:
+          - e2e-test
+
+- pipeline:
+    name: e2e-quick-test
+    description: |
+      Changes that have been seen by trusted reviewer who labeled PR by e2e-quick-test label
+    success-message: Build succeeded (e2e-quick-test pipeline).
+    failure-message: Build failed (e2e-quick-test pipeline).
+    dequeue-message: Build canceled (e2e-quick-test pipeline).
+    manager: independent
+    trigger:
+      githubzuulapp:
+        - event: pull_request
+          action: labeled
+          label:
+            - e2e-quick-test
+    start:
+      githubzuulapp:
+        check: 'in_progress'
+        comment: false
+    success:
+      githubzuulapp:
+        check: 'success'
+        comment: true
+        label:
+          - successful-e2e-quick-test
+        unlabel:
+          - e2e-quick-test
+          - failed-e2e-quick-test
+          - cancelled-e2e-quick-test
+    failure:
+      githubzuulapp:
+        check: 'failure'
+        comment: true
+        label:
+          - failed-e2e-quick-test
+        unlabel:
+          - e2e-quick-test
+    dequeue:
+      githubzuulapp:
+        check: cancelled
+        comment: true
+        label:
+          - cancelled-e2e-quick-test
+        unlabel:
+          - e2e-quick-test
+
+- pipeline:
+    name: unlabel-on-update-e2e-test
+    description: |
+      If a PR is updated and has the successful-e2e-test label, we want to remove that.
+    manager: independent
+    precedence: high
+    trigger:
+      githubzuulapp:
+        - event: pull_request
+          action:
+            - changed
+    require:
+      githubzuulapp:
+        label:
+          - successful-e2e-test
+    success:
+      githubzuulapp:
+        unlabel:
+          - successful-e2e-test
+        comment: false
+
+- pipeline:
+    name: unlabel-on-update-e2e-quick-test
+    description: |
+      If a PR is updated and has the successful-e2e-quick-test label, we want to remove that.
+    manager: independent
+    precedence: high
+    trigger:
+      githubzuulapp:
+        - event: pull_request
+          action:
+            - changed
+    require:
+      githubzuulapp:
+        label:
+          - successful-e2e-quick-test
+    success:
+      githubzuulapp:
+        unlabel:
+          - successful-e2e-quick-test
+        comment: false

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -42,3 +42,19 @@
       - name: clouds_conf
         secret: app_credential_cloud_conf
     run: playbooks/openstack-compliance-checks/flavor-check.yaml
+
+- semaphore:
+    name: semaphore-openstack-access
+    max: 1
+
+- job:
+    name: openstack-access-base
+    parent: base
+    pre-run: playbooks/openstack/access.yaml
+    semaphores:
+      - semaphore-openstack-access
+    vars:
+      cloud: "gx-scs-zuul"
+    secrets:
+      - secret: openstack-application-credential
+        name: openstack_appcred

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -13,4 +13,29 @@
           bO/hSGsaJe5NP0v+mioFUkHLrmizWCbMmN6YTvrfrAG4iUe/Vsxhq+TxD+emnSHbfqL5q
           5FZDvQd0x7YlhUINYlc4UYfd8DptVN0YI//f6EFJYTrw6g98+YJQXssk5xiR3f7bBkMZb
           lbBobCH+8/dysrXezCNoeJVRpF2nNpzkKGuF8iEJ9938ud+Al0v/npDspxhig0=
-          
+
+- secret:
+    name: openstack-application-credential
+    data:
+      id: !encrypted/pkcs1-oaep
+        - b2AFxWSBCoo2hbfwFpXPO/X/8fzVykwtItpjI6B24rg7oKi3GWr6YZ1O7uqVqB4b+X9bn
+          3iNnN1b8Koy+OANqiABCQtbOiYij4aB1REL8NDk+tIaN1cHK/0rQyxyY2ptS/ZXfSdcCm
+          9Sn5aVicJXuNh1Q2II2kPqgatB8Uw0YjbxPL1TTOPdIuC3+MxHZknYIQZ6AUK42KnLbve
+          ytSlywD22QOzN0+pUabGd7J+u9NQd/fkOTCXz8ZKu15eyYvfV4cD6BkTfisCDftbXz1ix
+          znjanI3TUT4ZUajt3zaT5cBvq7k6+BkMSpR+9X8OzVwz6hzpOZLc9ze28ZxZZwpmBNLdt
+          88W3ZG44ZbKeMmJO2LHd9/tQbU2VaSF2uKKbcgiCrS+7O1ad+lTjkhiR3lJW1PlEVL1ar
+          nG7O5mC/oWY4bNvplTl1lS1NrJpFBz5jUX2iT4gvZ4P5GNr0MNX6elKuucjQf6U+Meh6H
+          jYiDpiPk6MG2eMWXs5DUz3pklEPfdQ8jyKXijhxDy0AxWf584GuPQ6GcLugaZMseGGhtq
+          YqaAOUSRjxNhlc0IYIbsA1Tx+6zC1VZxW+HsV/YqTw7slIwrUHdtdLHN+xZnES/xq7ugH
+          LCK130C/znfSglqFzW2k1B6Pf1AICAtCIgNWvMDvgxHd62G941EPR4z00kxEpI=
+      secret: !encrypted/pkcs1-oaep
+        - bvcg9/Y3JjqJc3SxMkeh8f2GXCKPbyDfikYqlAZutwua7lebMb+XZQ+zRCq+soUvXl3oU
+          GA5BQI5LJThSX4NtYqc6D3z9iZbhfMnzr5w+QLOzAojkwkjhVWBXDnb9ZrizZ3cpcKFm+
+          S+dVFQlYBX0QluhVlD2X9ZqVUDh5oW96fgAU3WeDbi1mEieWqxczLr+c2dEnT/UUIhi+D
+          6ezh0clw602iHt9xSOliEaMlk6TbiUixntuJa86P3YW9ONHv4L/l5TAXMf9h/Pq5OAEJO
+          EAJcvubIX8/UESlQRmpd1GzQGEcEZrJw4Wn/LG+qcq4h55Bhr759HGsPvc5x4Q5CkvNVW
+          HmFMBc/RVLZSEdvuM9wtqy5XSohW2OZG7XmXDZcQiLCDT/kmfA+dnsMy/MQCPrYhHnKkO
+          1cwl8hFfCIaLazIW2wF6zGrir6+FGijWUO67YnC5XEylocIhq7OIR+ZNwjKD6B/T/VmrY
+          Neh0BZr2R9CTM1capGUrCN5bJ2GP0+MTC467d3WG3qO7IWz6sFeoJlnq5KaRr6hRCYO2w
+          j3zMJcwAmHKcnnTsKR5vnWYu5hC4Iv5fvcMR4mwi3Y1Juv/CUea3lFOibt6kRTinDhSGQ
+          ESBo/t5td7xSAMkn5KlkA/05B05XXoScwxr2wft3XE1/mJCAqQtuUkGvfV3g00=


### PR DESCRIPTION
This PR is based on work in the [matofederorg/zuul-config](https://github.com/matofederorg/zuul-config) repository. Thank you @matofeder!

PR targets epic SovereignCloudStack/issues#378.
Specifically, it resolves:
- SovereignCloudStack/issues#379
  - Trusted reviewer marks pull request with `e2e-test` or `e2e-quick-test` label. This triggers pipeline called **e2e-test** / **e2e-quick-test**
  - When the pipeline finishes, it removes the `e2e-test`/`e2e-quick-test` label
- SovereignCloudStack/issues#380
  - Six labels are introduced:
    - `successful-e2e-test`, `failed-e2e-test` and `cancelled-e2e-test` for **e2e-test** pipeline
    - `successful-e2e-quick-test`, `failed-e2e-quick-test` and `cancelled-e2e-quick-test` for **e2e-quick-test** pipeline
  - Labels are used based on the **e2e-test** pipeline's result:
    - **success**: adds `successful-e2e-test` label, removes `failed-e2e-test` and `cancelled-e2e-test` labels
    - **failure**: adds `failed-e2e-test` label
    - **dequeue**: adds  `cancelled-e2e-test` label
  - **e2e-quick-test** pipeline has the same logic as **e2e-test** pipeline
- SovereignCloudStack/issues#381
  - Pipelines **unlabel-on-update-e2e-test** and **unlabel-on-update-e2e-quick-test** are triggered when PR is changed(e.g. developer adds new commit). If the pipeline finds the `successful-e2e-test` / `successful-e2e-quick-test` label, it removes that.
- SovereignCloudStack/issues#406
  - Zuul semaphore **semaphore-openstack-access**  ensures that only one pipeline can run at a time

It also allows to use of these created pipelines and jobs in the k8s-cluster-api-provider repository for e2e tests(PR there will come soon).

Secrets(OpenStack application credentials) were generated by:
```bash
echo -n "<secret>" | zuul-client --zuul-url https://zuul.scs.community encrypt --tenant SCS --project github.com/SovereignCloudStack/zuul-config
```
Currently, for e2e tests, we are using the *p500924-gxhackathon6-1* plusserver project, because we found it unused. Once SovereignCloudStack/docs#42 is resolved, the wavestack project will be used and cloud credentials will be changed.

These secrets are used by job **openstack-access-base** which can be used by child jobs(specifying *parent:*). This job has a *pre-run* playbook, which writes *clouds/secure.yaml* to the */etc/openstack* directory, so it can be later used by child jobs for accessing the OpenStack project. Security is here guaranteed by the fact, that pipelines can be triggered only by the trusted reviewer - people outside the organization cannot add labels to PR.
**openstack-access-base** job is also limited by semaphore, which ensures that only one job can access OpenStack projects at a time.

Closes SovereignCloudStack/issues#379 SovereignCloudStack/issues#380 SovereignCloudStack/issues#381 SovereignCloudStack/issues#406