### PR TITLE
Update e2e-quick-test and e2e-test pipelines

### DIFF
--- a/zuul.d/gh_pipelines.yaml
+++ b/zuul.d/gh_pipelines.yaml
@@ -152,6 +152,8 @@
           - failed-e2e-test
         unlabel:
           - e2e-test
+          - successful-e2e-test
+          - cancelled-e2e-test
     dequeue:
       githubzuulapp:
         check: cancelled
@@ -160,6 +162,8 @@
           - cancelled-e2e-test
         unlabel:
           - e2e-test
+          - successful-e2e-test
+          - failed-e2e-test
 
 - pipeline:
     name: e2e-quick-test
@@ -197,6 +201,8 @@
           - failed-e2e-quick-test
         unlabel:
           - e2e-quick-test
+          - successful-e2e-quick-test
+          - cancelled-e2e-quick-test
     dequeue:
       githubzuulapp:
         check: cancelled
@@ -205,6 +211,8 @@
           - cancelled-e2e-quick-test
         unlabel:
           - e2e-quick-test
+          - successful-e2e-quick-test
+          - failed-e2e-quick-test
 
 - pipeline:
     name: unlabel-on-update-e2e-test


### PR DESCRIPTION
This PR ensures that e2e-quick-test and e2e-test pipelines leave only relevant PR label when they fail or when they are canceled. This should ensure that the PR reviewer sees only relevant label that reflects the latest state of e2e-quick-test and e2e-test pipelines.

See an example workflow, where the `successful-e2e-test` label should be removed (step 4):
1. The `e2e-test` pipeline is triggered by the `e2e-test` PR label
2. The `e2e-test` pipeline succeded and PR is labeled by the `successful-e2e-test` PR label
3. The `e2e-test` pipeline is executed again (without any PR update), but this attempt failed (e.g. service is temporarily unavailable)
4. The PR is labeled by the `failed-e2e-test` PR label and the PR label `successful-e2e-test` is removed from the PR