### PR TITLE
Fix encryption/decryption failures of secrets

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -32,16 +32,17 @@
     post-run:
       - playbooks/base/post-fetch.yaml
 
-- job:
-    name: openstack-scs-flavor-check
-    parent: base
-    description: |
-      A job to check if a IaaS provider is SCS compliance in
-      terms of flavor names
-    secrets:
-      - name: clouds_conf
-        secret: app_credential_cloud_conf
-    run: playbooks/openstack-compliance-checks/flavor-check.yaml
+# TODO: Uncomment this job once the app_credential_cloud_conf secret has been renewed.
+#- job:
+#    name: openstack-scs-flavor-check
+#    parent: base
+#    description: |
+#      A job to check if a IaaS provider is SCS compliance in
+#      terms of flavor names
+#    secrets:
+#      - name: clouds_conf
+#        secret: app_credential_cloud_conf
+#    run: playbooks/openstack-compliance-checks/flavor-check.yaml
 
 - semaphore:
     name: semaphore-openstack-access

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,9 +3,10 @@
     name: SovereignCloudStack/zuul-config
     default-branch: main
     merge-mode: "squash-merge"
-    compliance_check:
-      jobs:
-        - openstack-scs-flavor-check
+# TODO: Uncomment this pipeline once the app_credential_cloud_conf secret has been renewed.
+#    compliance_check:
+#      jobs:
+#        - openstack-scs-flavor-check
     check:
       jobs:
         - noop

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -1,41 +1,42 @@
 ---
-- secret:
-    name: app_credential_cloud_conf
-    data:
-      credentials: !encrypted/pkcs1-oaep
-        - ne/z0PvpW2/ByaQDCCJ3Pv22X/z2wFQFQFCopk1X34ZOm81cmNXdPivANXHF5ZYOOjz9c
-          zjAHfVGZwlekoZl2XS9Jy9Oiu+yFwS9S+LLXPVGOw4WGS8355QOI5SiggEuvQKMCwLUsg
-          R1EWLwga0ZMlsw81r/bW7Ka3qdl9oni8pc+jPSPxM58r+uMY6AE+njdhOMMA9mYuxVO0i
-          Zf8y8SxvjBJ+/STNPHk87wxH8LS/5fhFCbdHY873iOrsjA1KZLwiY7T9P6pgyQ11Xn8gb
-          gvmOS+ygb+IgPLojsO49z7OWmizV4Q4fM+BjXYmOk6FppsAgIp84q5gnIXZ15Rx3qtPph
-          wNtFyTYtpd+c5X46vYyYjxuGkdZNzTKlJKTnil5N1TslV4ZVKM5BxZasvpCw6QmkM261N
-          fMnmIV92SRKEDz4+phfB1/EOMEjQAttCuCOLBhBHFoVcQfmePs1zClQJchMAvteUTQ4Y1
-          u+NZZm+NAXOI2wG3kLETTTzceRLh5Xn/ZkcqFnkSYJhQVtoAuELsjfklMJyGQ1MAR/nzl
-          S4Fsq7l058YP4TOd2V5+NOEcKa4X8vRBxNMGHPec+vA5BhUKIrku9goKPuhQxLKM3g4U0
-          ZQ59tuvwGN3Ec8rfNN/1+dYfDNo13A9nkH+M0Z79+ZNA3GDXd517w8X4kPn5C0=
+# TODO: Encrypt this secret again using the present zuul-config repository key
+#- secret:
+#    name: app_credential_cloud_conf
+#    data:
+#      credentials: !encrypted/pkcs1-oaep
+#        - ne/z0PvpW2/ByaQDCCJ3Pv22X/z2wFQFQFCopk1X34ZOm81cmNXdPivANXHF5ZYOOjz9c
+#          zjAHfVGZwlekoZl2XS9Jy9Oiu+yFwS9S+LLXPVGOw4WGS8355QOI5SiggEuvQKMCwLUsg
+#          R1EWLwga0ZMlsw81r/bW7Ka3qdl9oni8pc+jPSPxM58r+uMY6AE+njdhOMMA9mYuxVO0i
+#          Zf8y8SxvjBJ+/STNPHk87wxH8LS/5fhFCbdHY873iOrsjA1KZLwiY7T9P6pgyQ11Xn8gb
+#          gvmOS+ygb+IgPLojsO49z7OWmizV4Q4fM+BjXYmOk6FppsAgIp84q5gnIXZ15Rx3qtPph
+#          wNtFyTYtpd+c5X46vYyYjxuGkdZNzTKlJKTnil5N1TslV4ZVKM5BxZasvpCw6QmkM261N
+#          fMnmIV92SRKEDz4+phfB1/EOMEjQAttCuCOLBhBHFoVcQfmePs1zClQJchMAvteUTQ4Y1
+#          u+NZZm+NAXOI2wG3kLETTTzceRLh5Xn/ZkcqFnkSYJhQVtoAuELsjfklMJyGQ1MAR/nzl
+#          S4Fsq7l058YP4TOd2V5+NOEcKa4X8vRBxNMGHPec+vA5BhUKIrku9goKPuhQxLKM3g4U0
+#          ZQ59tuvwGN3Ec8rfNN/1+dYfDNo13A9nkH+M0Z79+ZNA3GDXd517w8X4kPn5C0=
 
 - secret:
     name: openstack-application-credential
     data:
       id: !encrypted/pkcs1-oaep
-        - b2AFxWSBCoo2hbfwFpXPO/X/8fzVykwtItpjI6B24rg7oKi3GWr6YZ1O7uqVqB4b+X9bn
-          3iNnN1b8Koy+OANqiABCQtbOiYij4aB1REL8NDk+tIaN1cHK/0rQyxyY2ptS/ZXfSdcCm
-          9Sn5aVicJXuNh1Q2II2kPqgatB8Uw0YjbxPL1TTOPdIuC3+MxHZknYIQZ6AUK42KnLbve
-          ytSlywD22QOzN0+pUabGd7J+u9NQd/fkOTCXz8ZKu15eyYvfV4cD6BkTfisCDftbXz1ix
-          znjanI3TUT4ZUajt3zaT5cBvq7k6+BkMSpR+9X8OzVwz6hzpOZLc9ze28ZxZZwpmBNLdt
-          88W3ZG44ZbKeMmJO2LHd9/tQbU2VaSF2uKKbcgiCrS+7O1ad+lTjkhiR3lJW1PlEVL1ar
-          nG7O5mC/oWY4bNvplTl1lS1NrJpFBz5jUX2iT4gvZ4P5GNr0MNX6elKuucjQf6U+Meh6H
-          jYiDpiPk6MG2eMWXs5DUz3pklEPfdQ8jyKXijhxDy0AxWf584GuPQ6GcLugaZMseGGhtq
-          YqaAOUSRjxNhlc0IYIbsA1Tx+6zC1VZxW+HsV/YqTw7slIwrUHdtdLHN+xZnES/xq7ugH
-          LCK130C/znfSglqFzW2k1B6Pf1AICAtCIgNWvMDvgxHd62G941EPR4z00kxEpI=
+        - pOY6tOAkkKdy5dIkbcOZsVZnVMr3DRdA7dL9e/cIeZarTUFr+ES1UuBgbu/6duQck8j7p
+          Eo1R2WmlWVgwQl/lp94MIiL6gSLCF43CJs6eHVm++Oe4u4k6O5+vvkjvUlj3xh8djcgYI
+          E7A84CMkM7e3pdQPKW8wZB9jkuNx6pnBbYmzRABO26EDpNDXPz+oUpNEHCDBU9vzFkKrL
+          YVI2RISeNWhWLDsG2CqQvWkICDDxa6c1L/hOqG/YUGASllTqLdcEMqB6k9oNDUolo8uAf
+          iHA1j0npyTn1RFg70LE/qBxstslZuUwKQ8G1mJiJWC998lI9lrnM4cHRjwAwJ2mSMGwVN
+          M/6SyeVimlUxeAl3DahNjMCOrt29YrEK9LZl0l/LZFbBKLPrNoKOk+EQq8ahCJo3hSBPm
+          XuaU1BLOkAeLomevaMDWp+Pnk0LZdMTFFwy659FqK5aH4eDYr54/keBRgYXvtx2vgpXfS
+          2Idrt1No+RtiONY17MKghUfhS+sfzBchUR+mKxO5H1yc9Hkkjqniziz4yTNLQPBmuvaJM
+          TvMhbLEh3ndg2QGCL06qmrWne3gY0/1FEiLBQjyi6FDM62BmPmHKxbnYmImtwzjtbARqB
+          6cMhsDGOoxLQwdfgoH/okHf7c4EpfXnloAatu6C9NGLncR9uiFuH4J+kwKsDJk=
       secret: !encrypted/pkcs1-oaep
-        - bvcg9/Y3JjqJc3SxMkeh8f2GXCKPbyDfikYqlAZutwua7lebMb+XZQ+zRCq+soUvXl3oU
-          GA5BQI5LJThSX4NtYqc6D3z9iZbhfMnzr5w+QLOzAojkwkjhVWBXDnb9ZrizZ3cpcKFm+
-          S+dVFQlYBX0QluhVlD2X9ZqVUDh5oW96fgAU3WeDbi1mEieWqxczLr+c2dEnT/UUIhi+D
-          6ezh0clw602iHt9xSOliEaMlk6TbiUixntuJa86P3YW9ONHv4L/l5TAXMf9h/Pq5OAEJO
-          EAJcvubIX8/UESlQRmpd1GzQGEcEZrJw4Wn/LG+qcq4h55Bhr759HGsPvc5x4Q5CkvNVW
-          HmFMBc/RVLZSEdvuM9wtqy5XSohW2OZG7XmXDZcQiLCDT/kmfA+dnsMy/MQCPrYhHnKkO
-          1cwl8hFfCIaLazIW2wF6zGrir6+FGijWUO67YnC5XEylocIhq7OIR+ZNwjKD6B/T/VmrY
-          Neh0BZr2R9CTM1capGUrCN5bJ2GP0+MTC467d3WG3qO7IWz6sFeoJlnq5KaRr6hRCYO2w
-          j3zMJcwAmHKcnnTsKR5vnWYu5hC4Iv5fvcMR4mwi3Y1Juv/CUea3lFOibt6kRTinDhSGQ
-          ESBo/t5td7xSAMkn5KlkA/05B05XXoScwxr2wft3XE1/mJCAqQtuUkGvfV3g00=
+        - MZgEvHYWhB0hILrw9nCIY1mRyk4FK+wM7LCrnB1poH6kiEcB+OOMmtNnxFSbsGWKlTlmA
+          mWCl8/59ZBFr1MFGo6MMuqEbRmHqptO3vPSc2vyBm9viGhD+w8MMUW7wZs7AGlGNi1YZU
+          jXpEgp0rduzKV1OON6jg91AjKcuB/eeh8BPUYdSREyNCrcX9u9fI4NDqSvIr7ML0If+XB
+          sr6a35vIvh3+C56KnzU9aRvHm5WPwu0owa5P9KjbZ6tm64jtLjlmPYnmcDCW8+lpT8fx+
+          w2JV5O3JpNAFjzTCLcButhR2NCy4V1YIxhYCFuGNannNBExWa51gHdd4EsbyLNJzfE//2
+          OUpuxfL188iTS7jBbwofGW1RPw99qHHC6MX7tDGTsJDRcC2Xk1tKLkUtJ2g6hQ9BImsxU
+          8jsFv5t1Pc3iKPVvh3HSXj4yrOVgjFNb5Gin4IBKr1p8+R2XxrXSMUS8KOgiC5e2DBtty
+          g3RNexLKOq7EVEvZD6E+xijoiCBzY016LiBg9eL6l1jFXOH/VHBTdblBYnLJq1OlVDHD3
+          27BIRgcfz43Tu/EqtHDLdZgaKRd5dDWlpZrg+0xPrb0wbxB1DM4djbHIr/Fwi/EaWQ4cW
+          yGAJ+NPUZlPlnP73+iTt1D4XuFAmenC+yVmtLlnGDQk8HtjSlFBRuksB/eguqg=


### PR DESCRIPTION
This PR does:
- It encrypts the `openstack-application-credential` secret using the current zuul-config repository key
-  It comments out the 'app_credential_cloud_conf' secret and the related pipeline (`compliance_check`) and job (`openstack-scs-flavor-check`) because we currently do not know the decrypted form of the `app_credential_cloud_conf` secret