### PR TITLE
Update semaphore-openstack-access maximum number of running jobs to 3

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -46,7 +46,7 @@
 
 - semaphore:
     name: semaphore-openstack-access
-    max: 1
+    max: 3
 
 - job:
     name: openstack-access-base


### PR DESCRIPTION
As k8s-cluster-api-provider e2e plays have been improved (see [k8s-cluster-api-provider/#568](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/issues/568)), we can increase the maximum number of running (parallel) jobs to 3.