### PR TITLE
Compliance check job - add retries for Ansible Galaxy install

### DIFF
--- a/playbooks/openstack-compliance-checks/flavor-check.yaml
+++ b/playbooks/openstack-compliance-checks/flavor-check.yaml
@@ -18,6 +18,10 @@
       community.general.ansible_galaxy_install:
         type: collection
         name: openstack.cloud
+      register: install_collection_openstackcloud
+      until: "install_collection_openstackcloud is not failed"
+      retries: 5
+      delay: 5
 
     - name: Create cloud config dir
       ansible.builtin.file:

--- a/playbooks/openstack-compliance-checks/pre-flavor-check.yaml
+++ b/playbooks/openstack-compliance-checks/pre-flavor-check.yaml
@@ -18,3 +18,7 @@
       community.general.ansible_galaxy_install:
         type: collection
         name: openstack.cloud
+      register: install_collection_openstackcloud
+      until: "install_collection_openstackcloud is not failed"
+      retries: 5
+      delay: 5


### PR DESCRIPTION
This PR aims to add retries when Ansible tries to install the Ansible Collections for the compliance checks