### PR TITLE
Add tenant config to the repo

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -1,0 +1,64 @@
+---
+- tenant:
+    name: SCS
+    admin-rules:
+      - zuul-tenant-mgmt
+    exclude-unprotected-branches: true
+    max-job-timeout: 14400
+    max-nodes-per-job: 5
+    source:
+      github:
+        config-projects:
+          - SovereignCloudStack/zuul-config:
+              load-branch: main
+        untrusted-projects:
+          - SovereignCloudStack/Design-Docs
+          - SovereignCloudStack/Operational-Docs
+          - SovereignCloudStack/contributor-guide
+          - SovereignCloudStack/docker-horizon
+          - SovereignCloudStack/documentation
+          - SovereignCloudStack/generics
+          - SovereignCloudStack/graphics
+          - SovereignCloudStack/gx-scs-identity-provider
+          - SovereignCloudStack/infrastructure
+          - SovereignCloudStack/issues
+          - SovereignCloudStack/k8s-cassandra
+          - SovereignCloudStack/k8s-cluster-api-provider:
+              exclude-unprotected-branches: true
+          - SovereignCloudStack/k8s-cortex
+          - SovereignCloudStack/k8s-gatekeeper
+          - SovereignCloudStack/k8s-grafana
+          - SovereignCloudStack/k8s-harbor
+          - SovereignCloudStack/k8s-harbor-manual
+          - SovereignCloudStack/k8s-minio
+          - SovereignCloudStack/k8s-open-policy-agent
+          - SovereignCloudStack/k8s-operator-scylla
+          - SovereignCloudStack/k8s-os-health-monitor
+          - SovereignCloudStack/k8s-prometheus
+          - SovereignCloudStack/k8s-template
+          - SovereignCloudStack/openstack-flavor-manager
+          - SovereignCloudStack/openstack-health-monitor
+          - SovereignCloudStack/openstack-vyos-image
+          - SovereignCloudStack/poc-gardener
+          - SovereignCloudStack/poc-kubermatic
+          - SovereignCloudStack/poc-rancher
+          - SovereignCloudStack/security-infra-scan-pipeline:
+              exclude-unprotected-branches: true
+          - SovereignCloudStack/testbed-gx-iam
+          - SovereignCloudStack/testbed-gx-k8s
+          - SovereignCloudStack/testbed-gx-scs
+          - SovereignCloudStack/website
+          - SovereignCloudStack/zuul_deployment
+          - SovereignCloudStack/status-page-api
+          - SovereignCloudStack/standards:
+              exclude-unprotected-branches: true
+          - SovereignCloudStack/container-images
+          - SovereignCloudStack/zuul-mqtt-matrix-bridge
+          - SovereignCloudStack/cluster-stacks
+          - SovereignCloudStack/central-api
+      opendevorg:
+        untrusted-projects:
+          - zuul/zuul-jobs:
+              include:
+                - job
+  


### PR DESCRIPTION
In order to simplify Zuul operations put tenant config to the repo
directly.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
