### PR TITLE
Pause build of noble

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -62,7 +62,7 @@ diskimages:
     formats:
       - qcow2
     parent: base
-    pause: false
+    pause: true
     rebuild-age: 86400
     release: noble
     username: ubuntu


### PR DESCRIPTION
opendev did a small hack to be able to build ubuntu noble that was not
directly visible. Since we do only use released zuul images we cannot
build noble for now. Pause it.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
