### PR TITLE
Switch pod images to own registry

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -75,6 +75,7 @@ labels:
   - name: ubuntu-noble
   - name: pod-fedora-latest
   - name: pod-fedora-39
+  - name: pod-fedora-40
 
 providers:
   - name: osinfra
@@ -85,12 +86,17 @@ providers:
         labels:
           - name: pod-fedora-latest
             type: pod
-            image: quay.io/opentelekomcloud/zuul-fedora:39
+            image: registry.scs.community/zuul/zuul-fedora:40
             cpu: 2
             memory: 2048
           - name: pod-fedora-39
             type: pod
-            image: quay.io/opentelekomcloud/zuul-fedora:39
+            image: registry.scs.community/zuul/zuul-fedora:39
+            cpu: 2
+            memory: 2048
+          - name: pod-fedora-40
+            type: pod
+            image: registry.scs.community/zuul/zuul-fedora:40
             cpu: 2
             memory: 2048
 


### PR DESCRIPTION
Switch pod images to be read from registry.scs.community and add F40
label.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
