### PR TITLE
Disable gx-scs pool

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -125,7 +125,7 @@ providers:
             flavor-name: SCS-2V-8-20
             key-name: zuul-nodepool
             name: ubuntu-noble
-        max-servers: 10
+        max-servers: 0
         name: main
         networks:
           - zuul_network


### PR DESCRIPTION
set max-servers to 0 for the old gx-scs pool

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
