### PR TITLE
feat: Add ubuntu-noble diskimage for gx-scs2 pool

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -101,44 +101,10 @@ providers:
             memory: 2048
 
   - boot-timeout: 180
-    cloud: gx-scs
-    diskimages:
-      - name: ubuntu-jammy
-        pause: false
-    driver: openstack
-    launch-retries: 3
-    name: gx-scs
-    pools:
-      - labels:
-          - console-log: true
-            diskimage: ubuntu-jammy
-            flavor-name: SCS-2V-8-20
-            key-name: zuul-nodepool
-            name: ubuntu-jammy
-          - console-log: true
-            diskimage: ubuntu-jammy
-            flavor-name: SCS-4V-8-20
-            key-name: zuul-nodepool
-            name: ubuntu-jammy-large
-          - console-log: true
-            diskimage: ubuntu-noble
-            flavor-name: SCS-2V-8-20
-            key-name: zuul-nodepool
-            name: ubuntu-noble
-        max-servers: 0
-        name: main
-        networks:
-          - zuul_network
-        security-groups:
-          - zuul_secgroup
-    rate: 3.0
-    region-name: RegionOne
-
-  - boot-timeout: 180
     cloud: gx-scs2
     diskimages:
       - name: ubuntu-jammy
-        pause: false
+      - name: ubuntu-noble
     driver: openstack
     launch-retries: 3
     name: gx-scs2


### PR DESCRIPTION
Also drop gx-scs pool which is not there anymore.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
