### PR TITLE
feat: Remove archived repositories from zuul main config

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -34,9 +34,6 @@
           - SovereignCloudStack/scs-training-kaas-scripts
           - SovereignCloudStack/issues
           - SovereignCloudStack/minutes
-          - SovereignCloudStack/security-infra-scan-pipeline
-          - SovereignCloudStack/security-k8s-scan-pipeline
-          - SovereignCloudStack/defectdojo
           - SovereignCloudStack/website
           - SovereignCloudStack/standards
           - SovereignCloudStack/cloud-interconnect
@@ -64,6 +61,7 @@
 #          - SovereignCloudStack/container-images
 #          - SovereignCloudStack/contributor-guide
 #          - SovereignCloudStack/csctl-plugin-openstack
+#          - SovereignCloudStack/defectdojo
 #          - SovereignCloudStack/devicetype-library
 #          - SovereignCloudStack/docker-horizon
 #          - SovereignCloudStack/docs-page
@@ -105,6 +103,8 @@
 #          - SovereignCloudStack/scs-bootstrap-clusterstacks-openstack
 #          - SovereignCloudStack/scs-did-creator
 #          - SovereignCloudStack/scs-maschinenraum
+#          - SovereignCloudStack/security-infra-scan-pipeline
+#          - SovereignCloudStack/security-k8s-scan-pipeline
 #          - SovereignCloudStack/sonic-buildimage
 #          - SovereignCloudStack/status-magic-link-poc
 #          - SovereignCloudStack/status-page-api


### PR DESCRIPTION
## Summary

Removes repositories from `zuul/main.yaml` that have been archived in the SovereignCloudStack organization.

The following three repositories were moved from the active `untrusted-projects` list into the commented `archived-projects` section (alphabetically sorted), consistent with the pattern established in #89:

- `defectdojo`
- `security-infra-scan-pipeline`
- `security-k8s-scan-pipeline`